### PR TITLE
Fixing scramler for variable variable name

### DIFF
--- a/src/Naneau/Obfuscator/Node/Visitor/Scrambler.php
+++ b/src/Naneau/Obfuscator/Node/Visitor/Scrambler.php
@@ -63,6 +63,11 @@ abstract class Scrambler extends NodeVisitorAbstract
         // String/value to scramble
         $toScramble = $node->$var;
 
+        // We ignore to scramble if it's not string (ex: a variable variable name)
+        if (!is_string($toScramble)) {
+            return;
+        }
+
         // Make sure there's something to scramble
         if (strlen($toScramble) === 0) {
             throw new InvalidArgumentException(sprintf(


### PR DESCRIPTION
I investigated the error and found that it caused by the variable variable name (like `$$host` in `phpseclib/Net/SFTP/Stream.php` and `$$k` in `Sweety/Runner/HtmlRunner.php`), in this context, the node look like this (variable name is a `Node\Expr\Variable` instance):

```
PhpParser\Node\Expr\Variable#323 (2) {
  protected $subNodes =>
  array(1) {
    'name' =>
    class PhpParser\Node\Expr\Variable#322 (2) {
      protected $subNodes =>
      array(1) {
        ...
      }
      protected $attributes =>
      array(2) {
        ...
      }
    }
  }
  protected $attributes =>
  array(2) {
    'startLine' =>
    int(2)
    'endLine' =>
    int(2)
  }
}
```
So just ignore scrambling first Variable node in this case and everything is alright. This is input and output I got in `phpseclib/Net/SFTP/Stream.php` after I patched `Scrambler.php`:

- Input : `global $$host;`
- Output: `global ${$spcea704};`

https://github.com/naneau/php-obfuscator/issues/2 and https://github.com/naneau/php-obfuscator/issues/6 should be fixed in the PR.