### PR TITLE
ignore variable functions when renaming

### DIFF
--- a/src/Naneau/Obfuscator/Node/Visitor/TrackingRenamerTrait.php
+++ b/src/Naneau/Obfuscator/Node/Visitor/TrackingRenamerTrait.php
@@ -52,6 +52,11 @@ trait TrackingRenamerTrait
             return false;
         }
 
+        // Ignore variable functions
+        if (!is_string($method)) {
+            return false;
+        }
+
         return isset($this->renamed[$method]);
     }
 


### PR DESCRIPTION
A similar issue to https://github.com/naneau/php-obfuscator/commit/46824ea4347ef089b95d494baf7d2ed3c941041e except with variable functions rather than variable variable names.

The current head of master + this change work quite well, would be nice to have them tagged so you can install packages via composer rather than tracking master

Thanks for writing/maintaining this...