### PR TITLE
Comparing modifier types as equalities is broken.

### DIFF
--- a/src/Naneau/Obfuscator/Node/Visitor/ScramblePrivateMethod.php
+++ b/src/Naneau/Obfuscator/Node/Visitor/ScramblePrivateMethod.php
@@ -124,7 +124,7 @@ class ScramblePrivateMethod extends ScramblerVisitor
     {
         foreach ($nodes as $node) {
             // Scramble the private method definitions
-            if ($node instanceof ClassMethod && $node->type === ClassNode::MODIFIER_PRIVATE) {
+            if ($node instanceof ClassMethod && ($node->type & ClassNode::MODIFIER_PRIVATE)) {
 
                 // Record original name and scramble it
                 $originalName = $node->name;


### PR DESCRIPTION
It doesn't capture "final private" which is admittedly a weird modifier. PHP Parser returns types as a bit set.