### PR TITLE
Update StringScrambler.php

### DIFF
--- a/src/Naneau/Obfuscator/StringScrambler.php
+++ b/src/Naneau/Obfuscator/StringScrambler.php
@@ -39,6 +39,8 @@ class StringScrambler
             $this->setSalt(
                 md5(microtime(true) . rand(0,1))
             );
+        } else { 
+            $this->setSalt($salt); 
         }
     }
 


### PR DESCRIPTION
Extremely minor bug fix for constructing StringScrambler with a salt. The documentation implies that a salt can be passed in, but it currently cannot. This one line change fixes that.