### PR TITLE
Option to resume on error

### DIFF
--- a/src/Naneau/Obfuscator/Obfuscator/Event/FileError.php
+++ b/src/Naneau/Obfuscator/Obfuscator/Event/FileError.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * The file that handles parsing error events
+ *
+ * @package         Obfuscator
+ * @subpackage      Obfuscator
+ */
+
+namespace Naneau\Obfuscator\Obfuscator\Event;
+
+use Symfony\Component\EventDispatcher\Event;
+use Naneau\Obfuscator\Obfuscator\Event\File;
+
+/**
+ * FileError
+ *
+ * The file being obfuscated that causes an error
+ *
+ * @category        Naneau
+ * @package         Obfuscator
+ * @subpackage      Obfuscator
+ */
+class FileError extends File
+{
+    /**
+     * The error message from Exception
+     * @var string
+     **/
+    private $errorMessage;
+
+    /**
+     * Constructor
+     *
+     * @param string $file
+     * @return void
+     **/
+    public function __construct($file, $errorMessage)
+    {
+        parent::setFile($file);
+        $this->errorMessage = $errorMessage;
+    }
+
+    /**
+     * Get the error message
+     *
+     * @return string
+     */
+    public function getErrorMessage()
+    {
+        return $this->errorMessage;
+    }
+}


### PR DESCRIPTION
This pull request add an option `--ignore_error` so that when the obfuscator encounter any errors on a file, it will display the error message and continue with the next file. 