### PR TITLE
Fixed an issue to copy source files on windows os

### DIFF
--- a/src/Naneau/Obfuscator/Console/Command/ObfuscateCommand.php
+++ b/src/Naneau/Obfuscator/Console/Command/ObfuscateCommand.php
@@ -197,7 +197,14 @@ class ObfuscateCommand extends Command
         // FIXME implement native copy
         $output = array();
         $return = 0;
-        $command = sprintf('cp -rf %s %s', $from, $to);
+
+        if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+            // WINDOWS
+            $command = sprintf('XCOPY "%s" "%s" /hievry', $from, $to);
+        } else {
+            // *NIX
+            $command = sprintf('cp -rf %s %s', $from, $to);
+        }        
 
         exec($command, $output, $return);
 


### PR DESCRIPTION
The `cp` command works on *NIX platforms but not on Windows machines. So, there must be a conditional statement which checks the operating system name before it runs a command to copy any files to a new directory.