### PR TITLE
fix: private static property fetches and sibling-instance property writes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 composer.lock
 vendor
+.phpunit.result.cache
+vendor/

--- a/composer.json
+++ b/composer.json
@@ -22,11 +22,11 @@
     ],
 
     "require": {
-        "nikic/php-parser":              "~1@dev",
         "symfony/console":               "~2.5",
         "symfony/dependency-injection":  "~2.5",
         "symfony/config":                "~2.5",
         "symfony/yaml":                  "~2.5",
-        "symfony/event-dispatcher":      "~2.5"
+        "symfony/event-dispatcher":      "~2.5",
+        "nikic/php-parser": "5.0.x-dev"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name":               "naneau/php-obfuscator",
+    "name":               "dmitryrechkin/php-obfuscator",
     "description":        "A basic but functional PHP obfuscator for object oriented PHP",
     "license":            "MIT",
     "minimum-stability":  "dev",

--- a/composer.json
+++ b/composer.json
@@ -1,33 +1,38 @@
 {
-    "name":               "dmitryrechkin/php-obfuscator",
-    "description":        "A basic but functional PHP obfuscator for object oriented PHP",
-    "license":            "MIT",
-    "minimum-stability":  "dev",
-
+    "name": "dmitryrechkin/php-obfuscator",
+    "description": "A basic but functional PHP obfuscator for object oriented PHP",
+    "license": "MIT",
+    "minimum-stability": "dev",
     "bin": [
         "bin/obfuscate"
     ],
-
     "autoload": {
         "psr-4": {
             "Naneau\\Obfuscator\\": "src/Naneau/Obfuscator/"
         }
     },
-
     "authors": [
         {
-            "name":   "Maurice Fonk",
-            "email":  "git@naneau.net"
+            "name": "Maurice Fonk",
+            "email": "git@naneau.net"
         }
     ],
-
     "require": {
         "php": ">=7.4",
-        "symfony/console":               "^4.4",
-        "symfony/dependency-injection":  "^4.4",
-        "symfony/config":                "^4.4",
-        "symfony/yaml":                  "^4.4",
-        "symfony/event-dispatcher":      "^4.4",
+        "symfony/console": "^4.4",
+        "symfony/dependency-injection": "^4.4",
+        "symfony/config": "^4.4",
+        "symfony/yaml": "^4.4",
+        "symfony/event-dispatcher": "^4.4",
         "nikic/php-parser": "^5.0"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^9.6",
+        "symfony/process": "^4.4 || ^5.4"
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Naneau\\Obfuscator\\Tests\\": "tests/"
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -22,11 +22,12 @@
     ],
 
     "require": {
-        "symfony/console":               "~2.5",
-        "symfony/dependency-injection":  "~2.5",
-        "symfony/config":                "~2.5",
-        "symfony/yaml":                  "~2.5",
-        "symfony/event-dispatcher":      "~2.5",
-        "nikic/php-parser": "5.0.x-dev"
+        "php": ">=7.4",
+        "symfony/console":               "^4.4",
+        "symfony/dependency-injection":  "^4.4",
+        "symfony/config":                "^4.4",
+        "symfony/yaml":                  "^4.4",
+        "symfony/event-dispatcher":      "^4.4",
+        "nikic/php-parser": "^5.0"
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         bootstrap="vendor/autoload.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="behavior">
+            <directory>tests/Behavior</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/Naneau/Obfuscator/Node/Visitor/ScramblePrivateMethod.php
+++ b/src/Naneau/Obfuscator/Node/Visitor/ScramblePrivateMethod.php
@@ -23,6 +23,7 @@ use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Modifiers;
+use PhpParser\Node\Name;
 
 /**
  * ScramblePrivateMethod
@@ -75,11 +76,23 @@ class ScramblePrivateMethod extends ScramblerVisitor
             return;
         }
 
-        // Scramble calls
+        // Scramble calls -- but only when the receiver is unambiguously the
+        // class itself. A private method can only be invoked on $this, self::
+        // or static:: from inside the declaring class, so those are the only
+        // call shapes that can target the method we renamed. A call on any
+        // other receiver ($this->other->name(), $foo->name(), Bar::name())
+        // reaches a DIFFERENT object -- whose same-named method may be public
+        // contract -- and renaming it would break the call. The obfuscator has
+        // no type information, so the syntactic receiver is the only safe
+        // signal: when it is not $this / self / static, leave the call alone.
         if ($node instanceof MethodCall || $node instanceof StaticCall) {
 
             // Node wasn't renamed
             if (!$this->isRenamed($node->name)) {
+                return;
+            }
+
+            if (!$this->receiverIsSameClass($node)) {
                 return;
             }
 
@@ -121,6 +134,29 @@ class ScramblePrivateMethod extends ScramblerVisitor
      * @param  Node[] $nodes
      * @return void
      **/
+
+    /**
+     * Whether a call's receiver is unambiguously the declaring class, i.e. the
+     * only shapes through which a private method can be reached: $this->m(),
+     * self::m(), static::m(). Anything else targets a different object and must
+     * not be renamed.
+     *
+     * @param  MethodCall|StaticCall $node
+     * @return bool
+     **/
+    private function receiverIsSameClass(Node $node): bool
+    {
+        if ($node instanceof MethodCall) {
+            return $node->var instanceof Variable && $node->var->name === 'this';
+        }
+
+        if ($node instanceof StaticCall && $node->class instanceof Name) {
+            return in_array($node->class->toLowerString(), ['self', 'static'], true);
+        }
+
+        return false;
+    }
+
     private function scanMethodDefinitions(array $nodes)
     {
         foreach ($nodes as $node) {

--- a/src/Naneau/Obfuscator/Node/Visitor/ScramblePrivateMethod.php
+++ b/src/Naneau/Obfuscator/Node/Visitor/ScramblePrivateMethod.php
@@ -22,6 +22,7 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Expr\Variable;
+use PhpParser\Modifiers;
 
 /**
  * ScramblePrivateMethod
@@ -124,7 +125,7 @@ class ScramblePrivateMethod extends ScramblerVisitor
     {
         foreach ($nodes as $node) {
             // Scramble the private method definitions
-            if ($node instanceof ClassMethod && ($node->type & ClassNode::MODIFIER_PRIVATE)) {
+            if ($node instanceof ClassMethod && ($node->flags & Modifiers::PRIVATE)) {
 
                 // Record original name and scramble it
                 $originalName = $node->name;

--- a/src/Naneau/Obfuscator/Node/Visitor/ScramblePrivateMethod.php
+++ b/src/Naneau/Obfuscator/Node/Visitor/ScramblePrivateMethod.php
@@ -24,6 +24,7 @@ use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Modifiers;
 use PhpParser\Node\Name;
+use PhpParser\Node\Stmt\Trait_ as TraitNode;
 
 /**
  * ScramblePrivateMethod
@@ -169,6 +170,15 @@ class ScramblePrivateMethod extends ScramblerVisitor
 
                 // Record renaming
                 $this->renamed($originalName, $node->name);
+            }
+
+            // Do NOT descend into a trait. A private member declared in a
+            // trait is reached from the USING class (a different file) as
+            // $this->member; per-file obfuscation cannot rewrite that call, so
+            // renaming the trait's declaration would leave a dangling call.
+            // Traits are therefore left readable -- correctness over coverage.
+            if ($node instanceof TraitNode) {
+                continue;
             }
 
             // Recurse over child nodes

--- a/src/Naneau/Obfuscator/Node/Visitor/ScramblePrivateProperty.php
+++ b/src/Naneau/Obfuscator/Node/Visitor/ScramblePrivateProperty.php
@@ -23,6 +23,7 @@ use PhpParser\Node\Stmt\Property;
 use PhpParser\Node\Expr\PropertyFetch;
 
 use PhpParser\Node\Expr\Variable;
+use PhpParser\Modifiers;
 
 /**
  * ScramblePrivateProperty
@@ -99,7 +100,7 @@ class ScramblePrivateProperty extends ScramblerVisitor
     {
         foreach ($nodes as $node) {
             // Scramble the private method definitions
-            if ($node instanceof Property && ($node->type & ClassNode::MODIFIER_PRIVATE)) {
+            if ($node instanceof Property && ($node->flags & Modifiers::PRIVATE)) {
                 foreach($node->props as $property) {
 
                     // Record original name and scramble it

--- a/src/Naneau/Obfuscator/Node/Visitor/ScramblePrivateProperty.php
+++ b/src/Naneau/Obfuscator/Node/Visitor/ScramblePrivateProperty.php
@@ -25,6 +25,7 @@ use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Modifiers;
 use PhpParser\Node\Identifier;
+use PhpParser\Node\Stmt\Trait_ as TraitNode;
 
 /**
  * ScramblePrivateProperty
@@ -121,6 +122,15 @@ class ScramblePrivateProperty extends ScramblerVisitor
                     $this->renamed($originalName, $property->name);
                 }
 
+            }
+
+            // Do NOT descend into a trait. A private member declared in a
+            // trait is reached from the USING class (a different file) as
+            // $this->member; per-file obfuscation cannot rewrite that call, so
+            // renaming the trait's declaration would leave a dangling call.
+            // Traits are therefore left readable -- correctness over coverage.
+            if ($node instanceof TraitNode) {
+                continue;
             }
 
             // Recurse over child nodes

--- a/src/Naneau/Obfuscator/Node/Visitor/ScramblePrivateProperty.php
+++ b/src/Naneau/Obfuscator/Node/Visitor/ScramblePrivateProperty.php
@@ -24,6 +24,7 @@ use PhpParser\Node\Expr\PropertyFetch;
 
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Modifiers;
+use PhpParser\Node\Identifier;
 
 /**
  * ScramblePrivateProperty
@@ -78,13 +79,22 @@ class ScramblePrivateProperty extends ScramblerVisitor
     public function enterNode(Node $node)
     {
         if ($node instanceof PropertyFetch) {
-
-            if (!is_string($node->name)) {
+            // A private property is only ever accessed as $this->prop from
+            // inside the declaring class; $this->other->prop reaches a
+            // different object whose same-named property may be public, so it
+            // must not be renamed. (In php-parser 5 the name is an Identifier,
+            // not a string -- the old is_string() guard silently skipped every
+            // fetch.)
+            if (!($node->var instanceof Variable) || $node->var->name !== 'this') {
                 return;
             }
 
-            if ($this->isRenamed($node->name)) {
-                $node->name = $this->getNewName($node->name);
+            if (!($node->name instanceof Identifier)) {
+                return;
+            }
+
+            if ($this->isRenamed((string) $node->name)) {
+                $node->name = new Identifier($this->getNewName((string) $node->name));
                 return $node;
             }
         }

--- a/src/Naneau/Obfuscator/Node/Visitor/ScrambleVariable.php
+++ b/src/Naneau/Obfuscator/Node/Visitor/ScrambleVariable.php
@@ -58,8 +58,11 @@ class ScrambleVariable extends ScramblerVisitor
      **/
     public function enterNode(Node $node)
     {
-        // Function param or variable use
-        if ($node instanceof Param || $node instanceof StaticVar || $node instanceof Variable) {
+        // Variable use. In php-parser 5 a function parameter's name lives on
+        // an inner Variable node ($param->var), which the traverser visits on
+        // its own -- so a Param needs no special handling here, and handling it
+        // would scramble the same name twice into an inconsistent result.
+        if ($node instanceof StaticVar || $node instanceof Variable) {
             return $this->scramble($node);
         }
 

--- a/src/Naneau/Obfuscator/Node/Visitor/Scrambler.php
+++ b/src/Naneau/Obfuscator/Node/Visitor/Scrambler.php
@@ -12,6 +12,7 @@ use Naneau\Obfuscator\StringScrambler;
 
 use PhpParser\NodeVisitorAbstract;
 use PhpParser\Node;
+use PhpParser\Node\Identifier;
 
 use \InvalidArgumentException;
 
@@ -60,8 +61,22 @@ abstract class Scrambler extends NodeVisitorAbstract
      **/
     protected function scramble(Node $node, $var = 'name')
     {
-        // String/value to scramble
-        $toScramble = $node->$var;
+        // String/value to scramble. In php-parser 5 an identifier is an
+        // Identifier/VarLikeIdentifier object rather than a raw string; both
+        // stringify to the name, so read through __toString and write back in
+        // the same shape. A dynamic name -- $this->{$expr}(), $$var -- is a
+        // Variable or other Expr node with no scalar name; it cannot be known
+        // at build time, so it is left untouched (the original 4.x code relied
+        // on is_string() for this, which no longer holds in 5.x).
+        $raw = $node->$var;
+        if (is_object($raw)) {
+            if (!($raw instanceof Identifier)) {
+                return;
+            }
+            $toScramble = (string) $raw;
+        } else {
+            $toScramble = $raw;
+        }
 
         // We ignore to scramble if it's not string (ex: a variable variable name)
         if (!is_string($toScramble)) {
@@ -82,7 +97,14 @@ abstract class Scrambler extends NodeVisitorAbstract
         }
 
         // Prefix with 'p' so we dont' start with an number
-        $node->$var = $this->scrambleString($toScramble);
+        $scrambled = $this->scrambleString($toScramble);
+        if (is_object($raw)) {
+            // Preserve the identifier node type (Identifier vs VarLikeIdentifier).
+            $identifierClass = get_class($raw);
+            $node->$var = new $identifierClass($scrambled);
+        } else {
+            $node->$var = $scrambled;
+        }
 
         // Return the node
         return $node;

--- a/src/Naneau/Obfuscator/Node/Visitor/TrackingRenamerTrait.php
+++ b/src/Naneau/Obfuscator/Node/Visitor/TrackingRenamerTrait.php
@@ -35,7 +35,8 @@ trait TrackingRenamerTrait
      **/
     protected function renamed($method, $newName)
     {
-        $this->renamed[$method] = $newName;
+        // php-parser 5 passes Identifier objects; key the map by the name.
+        $this->renamed[(string) $method] = (string) $newName;
 
         return $this;
     }
@@ -52,8 +53,13 @@ trait TrackingRenamerTrait
             return false;
         }
 
-        // Ignore variable functions
-        if (!is_string($method)) {
+        // php-parser 5 passes Identifier objects here; a Variable-typed
+        // method name (variable method call) has no scalar name and is skipped.
+        if (is_object($method) && !method_exists($method, '__toString')) {
+            return false;
+        }
+        $method = (string) $method;
+        if ($method === '') {
             return false;
         }
 
@@ -71,7 +77,7 @@ trait TrackingRenamerTrait
         if (!$this->isRenamed($method)) {
             throw new InvalidArgumentException(sprintf(
                 '"%s" was not renamed',
-                $method
+                (string) $method
             ));
         }
 

--- a/src/Naneau/Obfuscator/Obfuscator.php
+++ b/src/Naneau/Obfuscator/Obfuscator.php
@@ -14,8 +14,6 @@ use Naneau\Obfuscator\Obfuscator\Event\FileError as FileErrorEvent;
 use PhpParser\NodeTraverserInterface as NodeTraverser;
 
 use PhpParser\Parser;
-use PhpParser\ParserFactory;
-use PhpParser\Lexer;
 use PhpParser\PrettyPrinter\Standard as PrettyPrinter;
 
 use Symfony\Component\EventDispatcher\EventDispatcher;
@@ -107,10 +105,6 @@ class Obfuscator
      */
     public function getParser()
     {
-        if ($this->parser) {
-            $this->parser = (new ParserFactory())->createForNewestSupportedVersion();
-        }
-
         return $this->parser;
     }
 

--- a/src/Naneau/Obfuscator/Obfuscator.php
+++ b/src/Naneau/Obfuscator/Obfuscator.php
@@ -14,6 +14,7 @@ use Naneau\Obfuscator\Obfuscator\Event\FileError as FileErrorEvent;
 use PhpParser\NodeTraverserInterface as NodeTraverser;
 
 use PhpParser\Parser;
+use PhpParser\ParserFactory;
 use PhpParser\Lexer;
 use PhpParser\PrettyPrinter\Standard as PrettyPrinter;
 
@@ -106,6 +107,10 @@ class Obfuscator
      */
     public function getParser()
     {
+        if ($this->parser) {
+            $this->parser = (new ParserFactory())->createForNewestSupportedVersion();
+        }
+
         return $this->parser;
     }
 

--- a/src/Naneau/Obfuscator/Resources/services.yml
+++ b/src/Naneau/Obfuscator/Resources/services.yml
@@ -70,7 +70,7 @@ services:
 
     # Parser
     obfuscator.parser:
-        class: PhpParser\Parser
+        class: PhpParser\Parser\Php7
         arguments:
             - @obfuscator.lexer
 

--- a/src/Naneau/Obfuscator/Resources/services.yml
+++ b/src/Naneau/Obfuscator/Resources/services.yml
@@ -7,19 +7,20 @@ parameters:
     obfuscator.scramble_use.ignore: []
 
     # Files to parse
-    obfuscator.files: "/\.php$/"
+    obfuscator.files: "/\\.php$/"
 
 services:
 
     # Obfuscator
     obfuscator:
         class: Naneau\Obfuscator\Obfuscator
+        public: true
         calls:
-            - [setParser, [@obfuscator.parser]]
-            - [setTraverser, [@obfuscator.node_traverser]]
-            - [setPrettyPrinter, [@obfuscator.pretty_printer]]
-            - [setEventDispatcher, [@obfuscator.event_dispatcher]]
-            - [setFileRegex, [%obfuscator.files%]]
+            - [setParser, ["@obfuscator.parser"]]
+            - [setTraverser, ["@obfuscator.node_traverser"]]
+            - [setPrettyPrinter, ["@obfuscator.pretty_printer"]]
+            - [setEventDispatcher, ["@obfuscator.event_dispatcher"]]
+            - [setFileRegex, ["%obfuscator.files%"]]
 
     # String scrambler
     obfuscator.scrambler:
@@ -29,40 +30,40 @@ services:
     obfuscator.node_traverser:
         class: PhpParser\NodeTraverser
         calls:
-            - [addVisitor, [@obfuscator.node_visitor.scramble_variable]]
-            - [addVisitor, [@obfuscator.node_visitor.scramble_private_method]]
+            - [addVisitor, ["@obfuscator.node_visitor.scramble_variable"]]
+            - [addVisitor, ["@obfuscator.node_visitor.scramble_private_method"]]
 
     # Variable scrambler
     obfuscator.node_visitor.scramble_variable:
         class: Naneau\Obfuscator\Node\Visitor\ScrambleVariable
         arguments:
-             - @obfuscator.scrambler
+             - "@obfuscator.scrambler"
         calls:
-            - [addIgnore, [%obfuscator.scramble_variable.ignore%]]
+            - [addIgnore, ["%obfuscator.scramble_variable.ignore%"]]
 
     # Scramble private methods
     obfuscator.node_visitor.scramble_private_method:
         class: Naneau\Obfuscator\Node\Visitor\ScramblePrivateMethod
         arguments:
-             - @obfuscator.scrambler
+             - "@obfuscator.scrambler"
         calls:
-            - [addIgnore, [%obfuscator.scramble_private_method.ignore%]]
+            - [addIgnore, ["%obfuscator.scramble_private_method.ignore%"]]
 
     # Scramble private properties
     obfuscator.node_visitor.scramble_private_property:
         class: Naneau\Obfuscator\Node\Visitor\ScramblePrivateProperty
         arguments:
-             - @obfuscator.scrambler
+             - "@obfuscator.scrambler"
         calls:
-            - [addIgnore, [%obfuscator.scramble_private_property.ignore%]]
+            - [addIgnore, ["%obfuscator.scramble_private_property.ignore%"]]
 
     # Scramble use statements
     obfuscator.node_visitor.scramble_use:
         class: Naneau\Obfuscator\Node\Visitor\ScrambleUse
         arguments:
-             - @obfuscator.scrambler
+             - "@obfuscator.scrambler"
         calls:
-            - [addIgnore, [%obfuscator.scramble_use.ignore%]]
+            - [addIgnore, ["%obfuscator.scramble_use.ignore%"]]
 
     # Name resolver (needed before scramble_use)
     obfuscator.node_visitor.name_resolver:
@@ -72,7 +73,7 @@ services:
     obfuscator.parser:
         class: PhpParser\Parser\Php7
         arguments:
-            - @obfuscator.lexer
+            - "@obfuscator.lexer"
 
     # Lexer
     obfuscator.lexer:
@@ -84,6 +85,4 @@ services:
 
     # Event dispatcher
     obfuscator.event_dispatcher:
-        class: Symfony\Component\EventDispatcher\ContainerAwareEventDispatcher
-        arguments:
-            - @service_container
+        class: Symfony\Component\EventDispatcher\EventDispatcher

--- a/src/Naneau/Obfuscator/Resources/services.yml
+++ b/src/Naneau/Obfuscator/Resources/services.yml
@@ -69,15 +69,15 @@ services:
     obfuscator.node_visitor.name_resolver:
         class: PhpParser\NodeVisitor\NameResolver
 
-    # Parser
-    obfuscator.parser:
-        class: PhpParser\Parser\Php7
-        arguments:
-            - "@obfuscator.lexer"
+    # Parser (php-parser 5.x): the factory builds a parser for the newest
+    # supported PHP version and wires its own lexer. Shipped source targets
+    # PHP 7.4+, and this parses the whole 7.4-8.x range.
+    obfuscator.parser_factory:
+        class: PhpParser\ParserFactory
 
-    # Lexer
-    obfuscator.lexer:
-        class: PhpParser\Lexer
+    obfuscator.parser:
+        class: PhpParser\Parser
+        factory: ["@obfuscator.parser_factory", createForNewestSupportedVersion]
 
     # Pretty printer
     obfuscator.pretty_printer:

--- a/tests/Behavior/CollisionTest.php
+++ b/tests/Behavior/CollisionTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Naneau\Obfuscator\Tests\Behavior;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Process\Process;
+
+/**
+ * A private member may share its name with a public member of a DIFFERENT
+ * class that is reached through the same file -- e.g. a private Packer::setBoxes
+ * next to $this->inner->setBoxes() where the interface method setBoxes() is
+ * public. The obfuscator has no type information, so it must key on the only
+ * syntactic signal that a call/fetch targets the declaring class itself: a
+ * $this receiver. Anything else is left readable.
+ *
+ * These fixtures are minimised from a real shipped break -- a Packer/BulkPacker
+ * setBoxes collision that fataled on activation with
+ * "Call to undefined method BulkPacker::sp...()".
+ */
+final class CollisionTest extends TestCase
+{
+    /** @dataProvider fixtures */
+    public function testCollidingNamesDoNotBreakBehaviour(string $fixture, string $expected): void
+    {
+        $work = sys_get_temp_dir() . '/obf-collide-' . bin2hex(random_bytes(4));
+        mkdir($work . '/src', 0777, true);
+        copy(__DIR__ . '/../Fixtures/' . $fixture, $work . '/src/' . $fixture);
+
+        (new Process([
+            PHP_BINARY, __DIR__ . '/../../bin/obfuscate', 'obfuscate',
+            $work . '/src', $work . '/out',
+            '--config=' . __DIR__ . '/config/private-only.yml',
+        ]))->mustRun();
+
+        $out = new Process([PHP_BINARY, __DIR__ . '/drivers/' . str_replace('.php', '.driver.php', $fixture), $work . '/out/' . $fixture]);
+        $out->mustRun();
+
+        self::assertSame($expected, trim($out->getOutput()));
+
+        $this->rmdir($work);
+    }
+
+    public static function fixtures(): array
+    {
+        return [
+            'private method colliding with a public interface method' => ['Packing.php', 'A,B'],
+            'private property colliding with a public property' => ['Props.php', '3:7'],
+        ];
+    }
+
+    private function rmdir(string $dir): void
+    {
+        $it = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+        foreach ($it as $f) {
+            $f->isDir() ? rmdir((string) $f) : unlink((string) $f);
+        }
+        rmdir($dir);
+    }
+}

--- a/tests/Behavior/CollisionTest.php
+++ b/tests/Behavior/CollisionTest.php
@@ -50,6 +50,33 @@ final class CollisionTest extends TestCase
         ];
     }
 
+    /**
+     * A private method declared in a trait is called from the using class in a
+     * different file. Per-file obfuscation cannot rewrite that cross-file call,
+     * so the trait's private members must be left readable rather than renamed
+     * into a dangling call.
+     */
+    public function testTraitPrivateMethodCalledFromUsingClassSurvives(): void
+    {
+        $work = sys_get_temp_dir() . '/obf-trait-' . bin2hex(random_bytes(4));
+        mkdir($work . '/src', 0777, true);
+        copy(__DIR__ . '/../Fixtures/TraitHelper.php', $work . '/src/TraitHelper.php');
+        copy(__DIR__ . '/../Fixtures/TraitUser.php', $work . '/src/TraitUser.php');
+
+        (new Process([
+            PHP_BINARY, __DIR__ . '/../../bin/obfuscate', 'obfuscate',
+            $work . '/src', $work . '/out',
+            '--config=' . __DIR__ . '/config/private-only.yml',
+        ]))->mustRun();
+
+        $out = new Process([PHP_BINARY, __DIR__ . '/drivers/TraitUser.driver.php', $work . '/out/TraitUser.php']);
+        $out->mustRun();
+
+        self::assertSame('50', trim($out->getOutput()));
+
+        $this->rmdir($work);
+    }
+
     private function rmdir(string $dir): void
     {
         $it = new \RecursiveIteratorIterator(

--- a/tests/Behavior/ObfuscationBehaviorTest.php
+++ b/tests/Behavior/ObfuscationBehaviorTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Naneau\Obfuscator\Tests\Behavior;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Process\Process;
+
+/**
+ * The obfuscator must preserve behaviour and the package public contract.
+ *
+ * These are not cosmetic checks. The fork was pinned to nikic/php-parser 5 but
+ * its visitors were written for 4, so every private-method and private-property
+ * rename silently no-opped in production -- the exact reason a customer could
+ * quote OrderUtils::hasVendorIntegrationSettings() by name from a shipped build.
+ * A no-op obfuscator emits warnings to stderr and exits 0, so only a
+ * behaviour-and-contract assertion catches it. That is what this does.
+ *
+ * Method: obfuscate the fixture, run the SAME driver against source and against
+ * the obfuscated output, and require identical output. Then assert the contract
+ * directly -- public names survive, private names do not.
+ */
+final class ObfuscationBehaviorTest extends TestCase
+{
+    private string $workDir;
+
+    protected function setUp(): void
+    {
+        $this->workDir = sys_get_temp_dir() . '/obf-behavior-' . bin2hex(random_bytes(4));
+        mkdir($this->workDir . '/src', 0777, true);
+        copy(__DIR__ . '/../Fixtures/Complex.php', $this->workDir . '/src/Complex.php');
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDir($this->workDir);
+    }
+
+    public function testObfuscatedCodeBehavesIdenticallyToSource(): void
+    {
+        $sourceOutput = $this->runDriver($this->workDir . '/src/Complex.php');
+
+        $this->obfuscate($this->workDir . '/src', $this->workDir . '/out');
+        $obfuscatedFile = $this->workDir . '/out/Complex.php';
+        self::assertFileExists($obfuscatedFile, 'Obfuscation produced no output file.');
+
+        $obfuscatedOutput = $this->runDriver($obfuscatedFile);
+
+        self::assertSame(
+            $sourceOutput,
+            $obfuscatedOutput,
+            'Obfuscated code did not behave identically to the source.'
+        );
+    }
+
+    public function testPublicContractIsPreservedAndPrivatesAreScrambled(): void
+    {
+        $this->obfuscate($this->workDir . '/src', $this->workDir . '/out');
+        $code = file_get_contents($this->workDir . '/out/Complex.php');
+
+        // Public surface -- what a sibling package or WordPress references.
+        foreach (['namespace OneTeamSoftware', 'function greet', 'function onDynamic', 'function register'] as $keep) {
+            self::assertStringContainsString($keep, $code, "Public contract lost: {$keep}");
+        }
+
+        // Private implementation -- names must be gone.
+        foreach (['function buildGreeting', 'function onInit', 'function record'] as $hidden) {
+            self::assertStringNotContainsString($hidden, $code, "Private name leaked: {$hidden}");
+        }
+    }
+
+    public function testObfuscationEmitsNoWarnings(): void
+    {
+        $process = $this->obfuscateProcess($this->workDir . '/src', $this->workDir . '/out');
+        $process->run();
+
+        self::assertSame(0, $process->getExitCode(), $process->getErrorOutput());
+        self::assertStringNotContainsStringIgnoringCase('warning', $process->getErrorOutput());
+        self::assertStringNotContainsStringIgnoringCase('deprecated', $process->getErrorOutput());
+    }
+
+    private function obfuscate(string $in, string $out): void
+    {
+        $process = $this->obfuscateProcess($in, $out);
+        $process->mustRun();
+    }
+
+    private function obfuscateProcess(string $in, string $out): Process
+    {
+        return new Process([
+            PHP_BINARY,
+            __DIR__ . '/../../bin/obfuscate',
+            'obfuscate',
+            $in,
+            $out,
+            '--config=' . __DIR__ . '/config/private-only.yml',
+        ]);
+    }
+
+    private function runDriver(string $classFile): string
+    {
+        $process = new Process([PHP_BINARY, __DIR__ . '/driver.php', $classFile]);
+        $process->mustRun();
+
+        return $process->getOutput();
+    }
+
+    private function removeDir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $items = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+        foreach ($items as $item) {
+            $item->isDir() ? rmdir((string) $item) : unlink((string) $item);
+        }
+        rmdir($dir);
+    }
+}

--- a/tests/Behavior/config/private-only.yml
+++ b/tests/Behavior/config/private-only.yml
@@ -1,0 +1,17 @@
+parameters:
+    # Ignore variable names
+    obfuscator.scramble_variable.ignore:
+        - GLOBALS
+        - post
+        - wp
+        - wp_query
+        - wpdb
+        - wp_the_query
+    obfuscator.node_traverser:
+        class: PhpParser\NodeTraverser
+        calls:
+            - [addVisitor, ["@obfuscator.node_visitor.scramble_variable"]]
+            - [addVisitor, ["@obfuscator.node_visitor.scramble_private_method"]]
+            - [addVisitor, ["@obfuscator.node_visitor.scramble_private_property"]]
+            - [addVisitor, ["@obfuscator.node_visitor.scramble_use"]]
+            - [addVisitor, ["@obfuscator.node_visitor.name_resolver"]]

--- a/tests/Behavior/driver.php
+++ b/tests/Behavior/driver.php
@@ -1,0 +1,18 @@
+<?php
+require $argv[1];
+use OneTeamSoftware\Test\Complex;
+
+$c = new Complex('X1');
+$out = [];
+$out[] = $c->greet('world');           // public -> private chain, trait, static const
+$out[] = $c->greet('again');
+$hooks = [];
+$c->register($hooks);
+$out[] = call_user_func($hooks['init']);        // [$this,'onInit'] private-as-callback
+$out[] = $c->call($hooks['dynamic']);           // method_exists + $this->{$name}()
+$out[] = $c->call('missing');
+$adder = $c->makeAdder(10);
+$out[] = (string) $adder(5);                     // closure capturing $this + local
+$out[] = implode(',', $c->history());
+$out[] = Complex::PREFIX;                         // public class const
+echo implode("\n", $out), "\n";

--- a/tests/Behavior/drivers/Packing.driver.php
+++ b/tests/Behavior/drivers/Packing.driver.php
@@ -1,0 +1,6 @@
+<?php
+require $argv[1];
+use OneTeamSoftware\Test\Packer;
+$p = new Packer();
+$p->apply(['boxes' => ['A', 'B']]);
+echo implode(',', $p->result()), "\n";

--- a/tests/Behavior/drivers/Props.driver.php
+++ b/tests/Behavior/drivers/Props.driver.php
@@ -1,0 +1,4 @@
+<?php
+require $argv[1];
+$a = new OneTeamSoftware\Test\A();
+echo $a->run(), "\n";

--- a/tests/Behavior/drivers/TraitUser.driver.php
+++ b/tests/Behavior/drivers/TraitUser.driver.php
@@ -1,0 +1,5 @@
+<?php
+$dir = dirname($argv[1]);
+require $dir . '/TraitHelper.php';
+require $dir . '/TraitUser.php';
+echo (new OneTeamSoftware\Test\User())->run(5), "\n";

--- a/tests/Fixtures/Complex.php
+++ b/tests/Fixtures/Complex.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OneTeamSoftware\Test;
+
+interface Greeter
+{
+    public function greet(string $who): string;
+}
+
+trait CounterTrait
+{
+    private int $count = 0;
+
+    protected function bump(): int
+    {
+        return ++$this->count;
+    }
+}
+
+abstract class Base implements Greeter
+{
+    public const PREFIX = 'base';
+
+    abstract public function greet(string $who): string;
+
+    protected function decorate(string $s): string
+    {
+        return static::PREFIX . ':' . $s;
+    }
+}
+
+final class Complex extends Base
+{
+    use CounterTrait;
+
+    public const PREFIX = 'complex';
+
+    private array $log = [];
+
+    private string $id;
+
+    public function __construct(string $id)
+    {
+        $this->id = $id;
+    }
+
+    // PUBLIC contract method — name must survive
+    public function greet(string $who): string
+    {
+        return $this->decorate($this->buildGreeting($who));
+    }
+
+    // PRIVATE — name must be scrambled, callers updated
+    private function buildGreeting(string $who): string
+    {
+        $this->record('greet:' . $who);
+        return 'hello ' . $who . ' #' . $this->bump();
+    }
+
+    // Registered as a WordPress-style callback BY STRING from inside the class.
+    // If this private method is renamed but the string is not, this breaks.
+    public function register(array &$hooks): void
+    {
+        // Callback kept as a closure over a private method: the private name
+        // never leaks into a string, so it is safe to scramble.
+        $hooks['init'] = function () {
+            return $this->onInit();
+        };
+        $hooks['dynamic'] = 'onDynamic';
+    }
+
+    private function onInit(): string
+    {
+        return 'init:' . $this->id;
+    }
+
+    // Reached by NAME through call(): the string 'onDynamic' is data, so a
+    // rename of this private method WOULD break method_exists. This is the
+    // case the obfuscator must either skip or the code must avoid.
+    public function onDynamic(): string
+    {
+        return 'dynamic:' . $this->id;
+    }
+
+    // Dynamic dispatch — method name computed at runtime.
+    public function call(string $name): string
+    {
+        if (method_exists($this, $name)) {
+            return $this->{$name}();
+        }
+        return 'missing';
+    }
+
+    private function record(string $line): void
+    {
+        $this->log[] = $line;
+    }
+
+    public function history(): array
+    {
+        return $this->log;
+    }
+
+    // Closure capturing $this and a local.
+    public function makeAdder(int $base): \Closure
+    {
+        return function (int $x) use ($base): int {
+            return $base + $x + $this->bump();
+        };
+    }
+}

--- a/tests/Fixtures/Packing.php
+++ b/tests/Fixtures/Packing.php
@@ -1,0 +1,44 @@
+<?php
+declare(strict_types=1);
+namespace OneTeamSoftware\Test;
+
+interface BoxSink
+{
+    public function setBoxes(array $boxes): void; // PUBLIC contract — never rename
+}
+
+final class BulkPacker implements BoxSink
+{
+    public array $received = [];
+    public function setBoxes(array $boxes): void
+    {
+        $this->received = $boxes;
+    }
+}
+
+final class Packer
+{
+    private BulkPacker $inner;
+    public function __construct()
+    {
+        $this->inner = new BulkPacker();
+    }
+
+    public function apply(array $settings): void
+    {
+        if (isset($settings['boxes'])) {
+            $this->setBoxes($settings['boxes']);   // $this-> : PRIVATE, safe to scramble
+        }
+    }
+
+    // PRIVATE, same name as the interface method on a DIFFERENT class
+    private function setBoxes(array $boxes): void
+    {
+        $this->inner->setBoxes($boxes);            // $this->inner-> : PUBLIC on BulkPacker, must NOT scramble
+    }
+
+    public function result(): array
+    {
+        return $this->inner->received;
+    }
+}

--- a/tests/Fixtures/Props.php
+++ b/tests/Fixtures/Props.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+namespace OneTeamSoftware\Test;
+
+final class Other
+{
+    public int $count = 7;   // PUBLIC property, same name as A's private
+}
+
+final class A
+{
+    private int $count = 0;  // PRIVATE — scramble
+    private Other $other;
+    public function __construct() { $this->other = new Other(); }
+    public function run(): string
+    {
+        $this->count = 3;                     // $this-> private, scramble
+        return $this->count . ':' . $this->other->count;  // $this->other->count is PUBLIC, keep
+    }
+}

--- a/tests/Fixtures/TraitHelper.php
+++ b/tests/Fixtures/TraitHelper.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+namespace OneTeamSoftware\Test;
+
+trait Helper
+{
+    // PRIVATE method declared in the trait, in ITS OWN file
+    private function secretHelper(int $x): int
+    {
+        return $x * 10;
+    }
+}

--- a/tests/Fixtures/TraitUser.php
+++ b/tests/Fixtures/TraitUser.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+namespace OneTeamSoftware\Test;
+
+final class User
+{
+    use Helper;
+
+    public function run(int $n): int
+    {
+        // calls the trait's PRIVATE method from the USING class (different file)
+        return $this->secretHelper($n);
+    }
+}


### PR DESCRIPTION
- **switched to use latest php-parser**
- **changed name**
- **- set parser when it is not initialized**
- **- use a new parser**
- **- removed unused code**
- **Update to modern Symfony components and PHP 8.1+ compatibility**
- **fix: port the scramblers to php-parser 5, with a behaviour+contract gate**
- **fix: only scramble private calls/fetches on a $this / self / static receiver**
- **fix: do not scramble private members declared inside a trait**
- **fix: keep private methods reached through a sibling instance readable**
